### PR TITLE
explicitly specify the chunking on open

### DIFF
--- a/pangeo_fish/io.py
+++ b/pangeo_fish/io.py
@@ -147,6 +147,9 @@ def open_copernicus_catalog(cat, chunks=None):
     ----------
     cat : intake.Catalog
         The pre-opened intake catalog
+    chunks : mapping, optional
+        The initial chunk size. Should be multiples of the on-disk chunk sizes. By
+        default, the chunksizes are ``{"lat": -1, "lon": -1, "depth": 11, "time": 8}``
 
     Returns
     -------


### PR DESCRIPTION
This allows for merging of `zarr` chunks *before* `dask` ever gets to see the small chunks, reducing the number of tasks by a *factor of 2* (which makes the difference between "possible to compute" and doesn't compute at all for the computation of differences for long time series).