### PR TITLE
use `tag_name` instead of trying to pull it out of the metadata

### DIFF
--- a/notebooks/full_workflow.ipynb
+++ b/notebooks/full_workflow.ipynb
@@ -382,7 +382,7 @@
     "diff = (\n",
     "    # TODO: rewrite the function to make it composable, using a depth threshold is too sharp.\n",
     "    diff_z(reference_model, reshaped_tag, depth_threshold=relative_depth_threshold)\n",
-    "    .assign_attrs({\"tag_id\": tag.attrs[\"pit_tag_id\"]})\n",
+    "    .assign_attrs({\"tag_id\": tag_name})\n",
     "    .assign(\n",
     "        {\n",
     "            \"H0\": reference_model[\"H0\"],\n",


### PR DESCRIPTION
We have been advertising the content of `metadata.json` to be purely optional, with this being an exception. However, since we also (should) have the same value in the `tag_name` variable, the exception can be removed.

Plus, apparently `pit_tag_id` is not universally used?