### PR TITLE
rename xarray-healpy/xarray_healpy where missing

### DIFF
--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -535,7 +535,7 @@
    "source": [
     "# Import necessary libraries\n",
     "import numpy as np\n",
-    "from xarray_healpy import HealpyGridInfo, HealpyRegridder\n",
+    "from xarray_regridding import HealpyGridInfo, HealpyRegridder\n",
     "from pangeo_fish.grid import center_longitude"
    ]
   },

--- a/pangeo_fish/acoustic.py
+++ b/pangeo_fish/acoustic.py
@@ -3,8 +3,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from tlz.itertoolz import first
-from xarray_healpy.conversions import geographic_to_cartesian
-from xarray_healpy.operations import buffer_points
+from xarray_regridding.conversions import geographic_to_cartesian
+from xarray_regridding.operations import buffer_points
 
 from pangeo_fish import utils
 from pangeo_fish.cf import bounds_to_bins

--- a/pangeo_fish/cli/prepare.py
+++ b/pangeo_fish/cli/prepare.py
@@ -1,6 +1,6 @@
 import numpy as np
 import xarray as xr
-from xarray_healpy import HealpyGridInfo, HealpyRegridder
+from xarray_regridding import HealpyGridInfo, HealpyRegridder
 
 from pangeo_fish.cf import bounds_to_bins
 from pangeo_fish.diff import diff_z

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "sparse",
     "healpy",
     "movingpandas",
-    "xarray-healpy"
+    "xarray-regridding"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
on GFTS, the example notebook `notebooks/pangeo-fish.ipynb` still fails with the optimiser:

```
%%time
# Fit the model parameter to the data
optimized = optimizer.fit(emission)
```

with the following error:

```
Func-count     x          f(x)          Procedure
    1       0.749978      2483.97        initial
    2        1.21343      2481.98        golden
    3        1.49986      2483.55        golden
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File <timed exec>:2

File [~/pangeo-fish/pangeo_fish/hmm/optimize/scipy.py:116](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/optimize/scipy.py#line=115), in EagerBoundsSearch.fit(self, X)
    113     return result.compute()
    115 lower, upper = self.param_bounds
--> 116 result = scipy.optimize.fminbound(
    117     f, lower, upper, args=(X,), **self.optimizer_kwargs
    118 )
    120 return self.estimator.set_params(sigma=result.item())

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/optimize/_optimize.py:2219](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/optimize/_optimize.py#line=2218), in fminbound(func, x1, x2, args, xtol, maxfun, full_output, disp)
   2137 """Bounded minimization for scalar functions.
   2138 
   2139 Parameters
   (...)
   2213 (4.000023843479476, 4.000023843479476)
   2214 """
   2215 options = {'xatol': xtol,
   2216            'maxiter': maxfun,
   2217            'disp': disp}
-> 2219 res = _minimize_scalar_bounded(func, (x1, x2), args, **options)
   2220 if full_output:
   2221     return res['x'], res['fun'], res['status'], res['nfev']

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/optimize/_optimize.py:2321](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/optimize/_optimize.py#line=2320), in _minimize_scalar_bounded(func, bounds, args, xatol, maxiter, disp, **unknown_options)
   2319 si = np.sign(rat) + (rat == 0)
   2320 x = xf + si * np.maximum(np.abs(rat), tol1)
-> 2321 fu = func(x, *args)
   2322 num += 1
   2323 fmin_data = (num, x, fu)

File [~/pangeo-fish/pangeo_fish/hmm/optimize/scipy.py:109](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/optimize/scipy.py#line=108), in EagerBoundsSearch.fit.<locals>.f(sigma, X)
    107 def f(sigma, X):
    108     # computing is important to avoid recomputing as many times as the result is used
--> 109     result = self.estimator.set_params(sigma=sigma).score(X)
    110     if not hasattr(result, "compute"):
    111         return result

File [~/pangeo-fish/pangeo_fish/hmm/estimator/eager.py:218](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/estimator/eager.py#line=217), in EagerEstimator.score(self, X, spatial_dims, temporal_dims)
    195 def score(self, X, *, spatial_dims=None, temporal_dims=None):
    196     """score the fit of the selected model to the data
    197 
    198     Apply the forward-backward algorithm to the given data, then return the
   (...)
    216         The score for the fit with the current parameters.
    217     """
--> 218     return self._score(
    219         X.fillna(0), spatial_dims=spatial_dims, temporal_dims=temporal_dims
    220     )

File [~/pangeo-fish/pangeo_fish/hmm/estimator/eager.py:72](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/estimator/eager.py#line=71), in EagerEstimator._score(self, X, spatial_dims, temporal_dims)
     64     temporal_dims = utils._detect_temporal_dims(X)
     66 input_core_dims = [
     67     temporal_dims + spatial_dims,
     68     spatial_dims,
     69     spatial_dims,
     70 ]
---> 72 value = xr.apply_ufunc(
     73     _algorithm,
     74     X.pdf.fillna(0),
     75     X.mask,
     76     X.initial,
     77     kwargs={"sigma": self.sigma, "truncate": self.truncate},
     78     input_core_dims=input_core_dims,
     79     output_core_dims=[()],
     80     dask="allowed",
     81 )
     82 gc.collect()
     83 return value.fillna(np.inf)

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/computation.py:1268](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/computation.py#line=1267), in apply_ufunc(func, input_core_dims, output_core_dims, exclude_dims, vectorize, join, dataset_join, dataset_fill_value, keep_attrs, kwargs, dask, output_dtypes, output_sizes, meta, dask_gufunc_kwargs, on_missing_core_dim, *args)
   1266 # feed DataArray apply_variable_ufunc through apply_dataarray_vfunc
   1267 elif any(isinstance(a, DataArray) for a in args):
-> 1268     return apply_dataarray_vfunc(
   1269         variables_vfunc,
   1270         *args,
   1271         signature=signature,
   1272         join=join,
   1273         exclude_dims=exclude_dims,
   1274         keep_attrs=keep_attrs,
   1275     )
   1276 # feed Variables directly through apply_variable_ufunc
   1277 elif any(isinstance(a, Variable) for a in args):

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/computation.py:312](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/computation.py#line=311), in apply_dataarray_vfunc(func, signature, join, exclude_dims, keep_attrs, *args)
    307 result_coords, result_indexes = build_output_coords_and_indexes(
    308     args, signature, exclude_dims, combine_attrs=keep_attrs
    309 )
    311 data_vars = [getattr(a, "variable", a) for a in args]
--> 312 result_var = func(*data_vars)
    314 out: tuple[DataArray, ...] | DataArray
    315 if signature.num_outputs > 1:

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/computation.py:821](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/computation.py#line=820), in apply_variable_ufunc(func, signature, exclude_dims, dask, output_dtypes, vectorize, keep_attrs, dask_gufunc_kwargs, *args)
    816     if vectorize:
    817         func = _vectorize(
    818             func, signature, output_dtypes=output_dtypes, exclude_dims=exclude_dims
    819         )
--> 821 result_data = func(*input_data)
    823 if signature.num_outputs == 1:
    824     result_data = (result_data,)

File [~/pangeo-fish/pangeo_fish/hmm/estimator/eager.py:53](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/estimator/eager.py#line=52), in EagerEstimator._score.<locals>._algorithm(emission, mask, initial, sigma, truncate)
     52 def _algorithm(emission, mask, initial, *, sigma, truncate):
---> 53     return score(
     54         emission,
     55         mask=mask,
     56         initial_probability=initial,
     57         sigma=sigma,
     58         truncate=truncate,
     59     )

File [~/pangeo-fish/pangeo_fish/hmm/filter.py:77](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/filter.py#line=76), in score(emission, sigma, initial_probability, mask, truncate)
     74 previous = initial
     76 for index in range(1, n_max):
---> 77     prediction = predict(
     78         previous,
     79         sigma=sigma,
     80         mask=mask,
     81         truncate=truncate,
     82     )
     83     updated = prediction * dask.compute(emission[index, ...])[0]
     85     normalizations.append(np.sum(updated))

File [~/pangeo-fish/pangeo_fish/hmm/filter.py:25](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/filter.py#line=24), in predict(X, sigma, mask, **kwargs)
     23 def predict(X, sigma, *, mask=None, **kwargs):
     24     filter_kwargs = {"mode": "constant", "cval": 0} | kwargs
---> 25     filtered = gaussian_filter(X, sigma=sigma, **filter_kwargs)
     27     if mask is None:
     28         return filtered

File [~/pangeo-fish/pangeo_fish/hmm/filter.py:20](https://gfts.minrk.net/user/annefou/pangeo-fish/pangeo_fish/hmm/filter.py#line=19), in gaussian_filter(X, sigma, **kwargs)
     13     return X.map_blocks(
     14         scipy.ndimage.gaussian_filter,
     15         sigma=sigma,
     16         meta=np.array((), dtype=X.dtype),
     17         **kwargs,
     18     )
     19 else:
---> 20     return scipy.ndimage.gaussian_filter(X, sigma=sigma, **kwargs)

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/ndimage/_filters.py:378](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/ndimage/_filters.py#line=377), in gaussian_filter(input, sigma, order, output, mode, cval, truncate, radius, axes)
    376 num_axes = len(axes)
    377 orders = _ni_support._normalize_sequence(order, num_axes)
--> 378 sigmas = _ni_support._normalize_sequence(sigma, num_axes)
    379 modes = _ni_support._normalize_sequence(mode, num_axes)
    380 radiuses = _ni_support._normalize_sequence(radius, num_axes)

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/ndimage/_ni_support.py:65](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/scipy/ndimage/_ni_support.py#line=64), in _normalize_sequence(input, rank)
     63 is_str = isinstance(input, str)
     64 if not is_str and isinstance(input, Iterable):
---> 65     normalized = list(input)
     66     if len(normalized) != rank:
     67         err = "sequence argument must have length equal to input rank"

File [/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/common.py:199](https://gfts.minrk.net/srv/conda/envs/notebook/lib/python3.12/site-packages/xarray/core/common.py#line=198), in AbstractArray.__iter__(self)
    197 def __iter__(self: Any) -> Iterator[Any]:
    198     if self.ndim == 0:
--> 199         raise TypeError("iteration over a 0-d array")
    200     return self._iter()

TypeError: iteration over a 0-d array
```