### PR TITLE
Catching up #112: warnings in case of missing receivers

### DIFF
--- a/pangeo_fish/acoustic.py
+++ b/pangeo_fish/acoustic.py
@@ -1,3 +1,4 @@
+import warnings
 import flox.xarray
 import numpy as np
 import pandas as pd
@@ -284,7 +285,16 @@ def emission_probability(
         grid[["cell_ids", "longitude", "latitude"]],
         buffer_size,
         method=cell_ids,
-    )
+    ).chunk() # chunks the map (to prevent autochunk which caused division by zero error)
+
+    maps_index = maps.indexes["deployment_id"]
+    weights_index = weights.indexes["deployment_id"]
+    if weights_index.difference(maps_index, sort=False).size > 0:
+        # print("WARNING: Some receiver ids `tag.acoustic` are not included in `tag.stations`.")
+        warnings.warn(
+            "Some receiver ids in `tag.acoustic` are not included in `tag.stations`.", 
+            UserWarning
+        )
 
     if nondetections == "ignore":
         fill_map = xr.ones_like(grid["cell_ids"], dtype=float).pipe(


### PR DESCRIPTION
Hi,
Sorry for catching up that way #112, but I failed to have it rebased correctly to `main`...
I dared to do so since the significance of the PR's contribution (small scope).
Thanks for the help @keewis!