### PR TITLE
Bbox argument in create_frame

### DIFF
--- a/pangeo_fish/visualization.py
+++ b/pangeo_fish/visualization.py
@@ -31,13 +31,18 @@ def create_frame(ds, figure, index, *args, **kwargs):
 
     projection = ccrs.Mercator()
     crs = ccrs.PlateCarree()
-    default_bbox = (
+    
+    default_xlim = [
         ds_["longitude"].min(),
-        ds_["longitude"].max(),
+        ds_["longitude"].max()
+    ]
+    default_ylim = [
         ds_["latitude"].min(),
-        ds_["latitude"].max(),
-    )
-    x0, x1, y0, y1 = kwargs.get("bbox", default_bbox)
+        ds_["latitude"].max()
+    ]
+    
+    x0, x1 = kwargs.get("xlim", default_xlim)
+    y0, y1 = kwargs.get("ylim", default_ylim)
 
     formatter = mticker.ScalarFormatter(useMathText=True)
     formatter.set_scientific(True)


### PR DESCRIPTION
Hi,

In order to set adequate `x` and `y` limitations when rendering frames of `states `and `emission `maps, I added a new optional parameter "bbox" in `create_frame`.
I set the default value as the one currently defined in the function.  

This can let the user better set the spatial boundaries upon plotting the frame.
### Before
![before](https://github.com/user-attachments/assets/65186892-2b7e-42b7-a963-70ff23ba37be)
### After
![after](https://github.com/user-attachments/assets/d3b776c6-139d-4e28-9d11-50121707fe36)
