### PR TITLE
Rendering images with xr.Dataset.map_blocks()

### DIFF
--- a/pangeo_fish/visualization.py
+++ b/pangeo_fish/visualization.py
@@ -1,6 +1,7 @@
 import warnings
 
 import matplotlib.pyplot as plt
+import xarray as xr
 
 import cartopy.crs as ccrs
 import cartopy.feature as cf
@@ -15,7 +16,31 @@ def filter_by_states(ds):
     return ds.where(ds["states"].sum(dim="time", skipna=True).compute() > 0, drop=True)
 
 
-def create_frame(ds, figure, index, *args, **kwargs):
+def create_single_frame(ds: xr.Dataset, figure, **kwargs):
+    """Default function for plotting a snapshot (i.e, **timeless** data) of the `emission` and `states` distributions.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        A **timeless** dataset, i.e., whose dimensions are `[x, y]`, that has the `emission` and `states` variables.
+    figure : A matplotlib Figure
+        The figure to which add the axes and plots
+    xlim : tuple[float, float], optional
+        The longitude interval to plot
+    ylim : tuple[float, float], optional
+        The latitude interval to plot
+    vmax : dict[str, float], optional
+        Mapping of the maximum values for coloring the plots, indexed by "emission" and "states"
+
+    Returns
+    -------
+    None : None
+        Nothing is returned
+    """
+
+    if sorted(list(ds.dims)) != ["x", "y"]:
+        raise ValueError(f"Malformed dataset (dims of {list(ds.dims)} instead of [x, y]).")
+
     warnings.filterwarnings(
         action="ignore",
         category=ShapelyDeprecationWarning,  # in cartopy
@@ -26,19 +51,18 @@ def create_frame(ds, figure, index, *args, **kwargs):
         message=r"No `(vmin|vmax)` provided. Data limits are calculated from input. Depending on the input this can take long. Pass `\1` to avoid this step",
     )
 
-    ds_ = ds.drop_vars(["resolution"], errors="ignore").isel(time=index, drop=True)
-    title = (
-        f"time = {np.datetime_as_string(ds['time'].isel(time=index).data, unit='s')}"
-    )
+    ds_ = ds.drop_vars(["resolution"], errors="ignore")
 
     projection = ccrs.Mercator()
     crs = ccrs.PlateCarree()
 
     default_xlim = [ds_["longitude"].min(), ds_["longitude"].max()]
     default_ylim = [ds_["latitude"].min(), ds_["latitude"].max()]
+    default_vmax = {"states": ds_["states"].max().to_numpy().item(), "emission": ds_["emission"].max().to_numpy().item()}
 
     x0, x1 = kwargs.get("xlim", default_xlim)
     y0, y1 = kwargs.get("ylim", default_ylim)
+    default_vmax.update(kwargs.get("vmax", {}))
 
     formatter = mticker.ScalarFormatter(useMathText=True)
     formatter.set_scientific(True)
@@ -50,9 +74,26 @@ def create_frame(ds, figure, index, *args, **kwargs):
         "aspect": 50,
         "format": formatter,
         "use_gridspec": True,
+        "extend": "max"
     }
-
-    gs = figure.add_gridspec(nrows=1, ncols=2, hspace=0, wspace=-0.2, top=0.9)
+    gridlines_kwargs = {
+        "crs": crs,
+        "draw_labels": True,
+        "linewidth": 0.6,
+        "color": "gray",
+        "alpha": 0.5,
+        "linestyle": "-.",
+    }
+    plot_kwargs = {
+        "x": "longitude",
+        "y": "latitude",
+        "transform": ccrs.PlateCarree(),
+        "cmap": "cool",
+        "xlim": [x0, x1],
+        "ylim": [y0, y1],
+        "vmin": 0
+    }
+    gs = figure.add_gridspec(nrows=1, ncols=2, hspace=0, wspace=-0.2, top=0.925)
     (ax1, ax2) = gs.subplots(
         subplot_kw={"projection": projection, "frameon": True},
         sharex=True,
@@ -60,186 +101,86 @@ def create_frame(ds, figure, index, *args, **kwargs):
     )
 
     ds_["states"].plot(
-        ax=ax1,
-        x="longitude",
-        y="latitude",
-        cbar_kwargs=cbar_kwargs | {"label": "State Probability"},
-        transform=ccrs.PlateCarree(),
-        cmap="cool",
-        xlim=[x0, x1],
-        ylim=[y0, y1],
+        **(
+            plot_kwargs |
+           {
+               "ax": ax1,
+               "cbar_kwargs": cbar_kwargs | {"label": "State Probability"},
+               "vmax": default_vmax["states"]
+            }
+        )
     )
-
+    ax1.set_title("")
     ax1.add_feature(cf.COASTLINE.with_scale("10m"), lw=0.5)
     ax1.add_feature(cf.BORDERS.with_scale("10m"), lw=0.3)
     ax1.set_extent([x0, x1, y0, y1], crs=crs)
-    gl1 = ax1.gridlines(
-        crs=crs,
-        draw_labels=True,
-        linewidth=0.6,
-        color="gray",
-        alpha=0.5,
-        linestyle="-.",
-    )
+    gl1 = ax1.gridlines(**gridlines_kwargs)
     gl1.right_labels = False
     gl1.top_labels = False
 
     ds_["emission"].plot(
-        ax=ax2,
-        x="longitude",
-        y="latitude",
-        cbar_kwargs=cbar_kwargs | {"label": "Emission Probability"},
-        transform=ccrs.PlateCarree(),
-        cmap="cool",
-        xlim=[x0, x1],
-        ylim=[y0, y1],
+        **(
+            plot_kwargs |
+           {
+               "ax": ax2,
+               "cbar_kwargs": cbar_kwargs | {"label": "Emission Probability"},
+               "vmax": default_vmax["emission"]
+            }
+        )
     )
+    ax2.set_title("")
     ax2.add_feature(cf.COASTLINE.with_scale("10m"), lw=0.5)
     ax2.add_feature(cf.BORDERS.with_scale("10m"), lw=0.3)
     ax2.set_extent([x0, x1, y0, y1], crs=crs)
 
-    gl2 = ax2.gridlines(
-        crs=crs,
-        draw_labels=True,
-        linewidth=0.6,
-        color="gray",
-        alpha=0.5,
-        linestyle="-.",
-    )
+    gl2 = ax2.gridlines(**gridlines_kwargs)
     gl2.left_labels = False
     gl2.top_labels = False
 
-    figure.suptitle(title)
-
-    return None, None
+    return None
 
 
-def render_frame(ds, *args, **kwargs):
+
+def render_frame(ds: xr.Dataset, *args, figsize=(14, 8), frames_dir=".", **kwargs):
     """
-        .. warning::
-            To use with `dask.map_blocks()`
-            `ds` must have the variable "time_index", representing the time index.
+    .. Warning::
+        Designed to be used with `dask.map_blocks()`.
+        As such, `ds` must have the following variables:
+            - `time_index`, representing the time index. It is used for naming the image (`.png`)
+            - `emission` and `states`, the data to plot
 
-     Parameters
-        ----------
-        output : str, "."
-            Name of the folder to save the frame
+    Used along with `dask.map_blocks()`, it will call create_single_frame() for each timestep,\
+    and save the consequent images under `{frames_dir}/frame_XXXXX.png`.
+
+    Parameters
+    ----------
+    frames_dir : str, default: "."
+        Name of the folder to save the frame
+    figsize : tuple[float, float], default: (14, 8)
+        Name of the folder to save the frame
+
+    Returns
+    -------
+    ds : xr.Dataset
+        The input dataset (see `dask.map_blocks()`)
     """
-    def _render_frame(ds, figure, **kwargs):
-        """render a frame
 
-        Parameters
-        ----------
-        vmax : dict[str, float], default to {"states": None, "emission": None}
-            Mpping of the vmax values for the pdfs `states` and `emission`
-
-        Returns
-        -------
-        fig : Figure
-            The plt.Figure
-        """
-        time = ds["time"].values[0]
-        ds_ = ds.drop_vars(["resolution"], errors="ignore")
-        title = (
-            f"Time = {np.datetime_as_string(time, unit="s")}"
-        )
-        projection = ccrs.Mercator()
-        crs = ccrs.PlateCarree()
-
-        default_xlim = [ds_["longitude"].min(), ds_["longitude"].max()]
-        default_ylim = [ds_["latitude"].min(), ds_["latitude"].max()]
-
-        x0, x1 = kwargs.get("xlim", default_xlim)
-        y0, y1 = kwargs.get("ylim", default_ylim)
-        vmax = kwargs.get("vmax", {})
-
-        formatter = mticker.ScalarFormatter(useMathText=True)
-        formatter.set_scientific(True)
-        formatter.set_powerlimits((-1, 1))
-
-        cbar_kwargs = {
-            "orientation": "horizontal",
-            "shrink": 0.65,
-            "pad": 0.05,
-            "aspect": 50,
-            "format": formatter,
-            "use_gridspec": True,
-            "extend": "max"
-        }
-
-        gs = figure.add_gridspec(nrows=1, ncols=2, hspace=0, wspace=-0.2, top=0.9)
-        (ax1, ax2) = gs.subplots(
-            subplot_kw={"projection": projection, "frameon": True},
-            sharex=True,
-            sharey=True,
-        )
-
-        ds_["states"].plot(
-            ax=ax1,
-            x="longitude",
-            y="latitude",
-            cbar_kwargs=cbar_kwargs | {"label": "State Probability"},
-            transform=ccrs.PlateCarree(),
-            cmap="cool",
-            xlim=[x0, x1],
-            ylim=[y0, y1],
-            vmin=0,
-            vmax=vmax.get("states", None)
-        )
-
-        ax1.add_feature(cf.COASTLINE.with_scale("10m"), lw=0.5)
-        ax1.add_feature(cf.BORDERS.with_scale("10m"), lw=0.3)
-        ax1.set_extent([x0, x1, y0, y1], crs=crs)
-        gl1 = ax1.gridlines(
-            crs=crs,
-            draw_labels=True,
-            linewidth=0.6,
-            color="gray",
-            alpha=0.5,
-            linestyle="-.",
-        )
-        gl1.right_labels = False
-        gl1.top_labels = False
-
-        ds_["emission"].plot(
-            ax=ax2,
-            x="longitude",
-            y="latitude",
-            cbar_kwargs=cbar_kwargs | {"label": "Emission Probability"},
-            transform=ccrs.PlateCarree(),
-            cmap="cool",
-            xlim=[x0, x1],
-            ylim=[y0, y1],
-            vmin=0,
-            vmax=vmax.get("emission", None)
-        )
-        ax2.add_feature(cf.COASTLINE.with_scale("10m"), lw=0.5)
-        ax2.add_feature(cf.BORDERS.with_scale("10m"), lw=0.3)
-        ax2.set_extent([x0, x1, y0, y1], crs=crs)
-
-        gl2 = ax2.gridlines(
-            crs=crs,
-            draw_labels=True,
-            linewidth=0.6,
-            color="gray",
-            alpha=0.5,
-            linestyle="-.",
-        )
-        gl2.left_labels = False
-        gl2.top_labels = False
-
-        figure.suptitle(title)
-        ax1.set_title("")
-        ax2.set_title("")
-        return figure
-
-    figure = plt.figure(figsize=(14, 8)) # figsize=(12, 6)
+    figure = plt.figure(figsize=figsize) # figsize=(12, 6)
 
     try:
-        _render_frame(ds, figure, **kwargs)
+        if ds.sizes["time"] > 1:
+            warnings.warn(
+                f"Multiple timesteps detected in `ds` (size: {ds.sizes["time"]}): only the first one will be rendered.",
+                UserWarning
+            )
+
+        create_single_frame(ds.isel(time=0), figure, **kwargs) # xr.Dataset.squeeze()?
+        time = ds["time"].values[0]
+        title = f"Time = {np.datetime_as_string(time, unit="s")}"
+        figure.suptitle(title)
+
         time_index = ds["time_index"].values[0]
-        frame_dir = kwargs.get("output", ".")
-        figure.savefig(f"{frame_dir}/frame_{time_index:05d}.png")#, bbox_inches="tight", pad_inches=0.2)
+        figure.savefig(f"{frames_dir}/frame_{time_index:05d}.png")#, bbox_inches="tight", pad_inches=0.2)
     except Exception as e:
         print(f"============ Exception at time {ds["time_index"].values[0]} ==============")
         print(e)


### PR DESCRIPTION
Hi,

Not sure if I incorporate it well within the library, but I added a function to use with `xr.Dataset.map_blocks()`.
From my experience, it is much faster and stable than using `xmovie` (with which we additionally render a `.mp4` video afterwards; see the notebook).

I am also working on helper functions: one of them will take of "preparing" the dataset to work with the function (i.e., adding the `time_index` variable).

Ideally, later on we would revise `create_frame()` (currently implemented to work with `xmovie`) so that the function actually uses `create_frame()` (instead `_render_frame()`).