### PR TITLE
proposition for using copernicusmarine

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - eccodes>=2.35.0
   - altair
   - cdshealpix
-  - copernicusmarine
+  - copernicusmarine>=2.4.1
   - dask-image
   - pip
   - pip:

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -169,7 +169,7 @@
     "relative_depth_threshold = 0.8\n",
     "\n",
     "# refinement level  defines the resolution of the healpix grid used for regridding.\n",
-    "refinement_level = 12  # int(log2(4098))\n",
+    "refinement_level = 10  # int(log2(4098))\n",
     "\n",
     "# min_vertices sets the minimum number of vertices for a valid transcription for regridding.\n",
     "min_vertices = 1\n",
@@ -332,42 +332,144 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
+   "id": "1dc2c1f9-6ed5-4d5f-b481-a0d83a0a1eb9",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from pangeo_fish.helpers import load_model, compute_diff\n",
+    "import numpy as np\n",
     "\n",
-    "reference_model = load_model(\n",
-    "    uri=ref_url,\n",
-    "    tag_log=tag_log,\n",
-    "    time_slice=time_slice,\n",
-    "    bbox=(bbox | {\"max_depth\": tag_log[\"pressure\"].max()}),\n",
-    "    chunk_time=chunk_time,\n",
-    "    remote_options={},\n",
+    "ds = tag[\"/dst\"]\n",
+    "\n",
+    "\n",
+    "first_datetime = ds.time.values[0]\n",
+    "last_datetime  = ds.time.values[-1]\n",
+    "\n",
+    "\n",
+    "first_day = np.datetime_as_string(first_datetime, unit='D')\n",
+    "last_day  = np.datetime_as_string(last_datetime, unit='D')\n",
+    "\n",
+    "print(first_day, last_day)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4b17884-5f97-4723-b08f-99aca6a99983",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copernicusmarine\n",
+    "from pangeo_fish.io import prepare_dataset\n",
+    "\n",
+    "ds_thetao = copernicusmarine.open_dataset(\n",
+    "    dataset_id=\"cmems_mod_ibi_phy-temp_my_0.027deg_P1D-m\",\n",
+    "    variables=[\"thetao\"],\n",
+    "    minimum_longitude=bbox[\"longitude\"][0],\n",
+    "    maximum_longitude=bbox[\"longitude\"][1],\n",
+    "    minimum_latitude=bbox[\"latitude\"][0],\n",
+    "    maximum_latitude=bbox[\"latitude\"][1],\n",
+    "    start_datetime=first_day,\n",
+    "    end_datetime=last_day,\n",
+    " )\n",
+    "\n",
+    "ds_zos= copernicusmarine.open_dataset(\n",
+    "    dataset_id=\"cmems_mod_ibi_phy-ssh_my_0.027deg_P1D-m\",\n",
+    "    variables=[\"zos\"],\n",
+    "    minimum_longitude=bbox[\"longitude\"][0],\n",
+    "    maximum_longitude=bbox[\"longitude\"][1],\n",
+    "    minimum_latitude=bbox[\"latitude\"][0],\n",
+    "    maximum_latitude=bbox[\"latitude\"][1],\n",
+    "    start_datetime=first_day,\n",
+    "    end_datetime=last_day,\n",
     ")\n",
+    "\n",
+    "\n",
+    "static_var = copernicusmarine.open_dataset(\n",
+    "    dataset_id=\"cmems_mod_ibi_phy_my_0.027deg-3D_static\",\n",
+    "    variables=[\"deptho\", \"mask\"],\n",
+    "    minimum_longitude=bbox[\"longitude\"][0],\n",
+    "    maximum_longitude=bbox[\"longitude\"][1],\n",
+    "    minimum_latitude=bbox[\"latitude\"][0],\n",
+    "    maximum_latitude=bbox[\"latitude\"][1],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8c36b3d-b01b-48f1-887e-76cc0b7f2412",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "static_var = static_var.assign_coords(longitude=ds_thetao[\"longitude\"].values)\n",
+    "\n",
+    "ds_all = xr.merge([ds_thetao,ds_zos, static_var], compat=\"no_conflicts\")\n",
+    "ds_all = ds_all.rename({\"latitude\": \"lat\", \"longitude\": \"lon\"})\n",
+    "model = prepare_dataset(ds_all)\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90e8c85c-2fa4-4144-8cbf-00917d44cca4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pangeo_fish.cf import bounds_to_bins\n",
+    "from pangeo_fish.tags import adapt_model_time, reshape_by_bins, to_time_slice\n",
+    "\n",
+    "tag_log[\"time\"] = tag_log[\"time\"].dt.floor(\"D\")\n",
+    "start = pd.Timestamp(tag_log[\"time\"].min().item())\n",
+    "end = pd.Timestamp(tag_log[\"time\"].max().item())\n",
+    "\n",
+    "extended_time_slice = slice(start, end)\n",
+    "\n",
+    "reference_model = (\n",
+    "    model.sel(time=adapt_model_time(extended_time_slice))\n",
+    "    .sel(lat=slice(*bbox[\"latitude\"]), lon=slice(*bbox[\"longitude\"]))\n",
+    "    .pipe(\n",
+    "        lambda ds: ds.sel(\n",
+    "            depth=slice(None, (tag_log[\"pressure\"].max() + 100).compute())\n",
+    "        )\n",
+    "    )\n",
+    ").chunk({\"time\": chunk_time, \"lat\": -1, \"lon\": -1, \"depth\": -1})\n",
+    "\n",
     "reference_model"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
+   "id": "4b6109eb-2255-41e8-bb00-6a437ef1ceb9",
+   "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
+    "# Reshape the tag log, so that it bins to the time step of reference_model\n",
+    "reshaped_tag = reshape_by_bins(\n",
+    "    tag_log,\n",
+    "    dim=\"time\",\n",
+    "    bins=(\n",
+    "        reference_model.cf.add_bounds([\"time\"], output_dim=\"bounds\")\n",
+    "        .pipe(bounds_to_bins, bounds_dim=\"bounds\")\n",
+    "        .get(\"time_bins\")\n",
+    "    ),\n",
+    "    other_dim=\"obs\",\n",
+    ").chunk({\"time\": chunk_time})\n",
+    "\n",
+    "reshaped_tag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7136974-6351-4b48-8aac-50b5eb9f111c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pangeo_fish.helpers import compute_diff\n",
     "diff = compute_diff(\n",
     "    reference_model=reference_model,\n",
     "    tag_log=tag_log,\n",
@@ -387,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "b579e381-6189-421a-8840-241ae8e17ab6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,6 +513,7 @@
    "id": "18",
    "metadata": {
     "editable": true,
+    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -418,7 +521,9 @@
    },
    "outputs": [],
    "source": [
-    "diff.to_zarr(f\"{target_root}/diff.zarr\", mode=\"w\", storage_options=storage_options)"
+    "diff.to_zarr(f\"{target_root}/diff.zarr\", mode=\"w\",\n",
+    "             zarr_version=2,\n",
+    "             storage_options=storage_options)"
    ]
   },
   {
@@ -525,6 +630,7 @@
     "    mode=\"w\",\n",
     "    consolidated=True,\n",
     "    compute=True,\n",
+    "    zarr_version=2,\n",
     "    storage_options=storage_options,\n",
     ")"
    ]
@@ -611,14 +717,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "31",
    "metadata": {
     "editable": true,
@@ -652,6 +750,7 @@
     "    mode=\"w\",\n",
     "    consolidated=True,\n",
     "    storage_options=storage_options,\n",
+    "    zarr_version=2\n",
     ")"
    ]
   },
@@ -692,6 +791,7 @@
    "id": "35",
    "metadata": {
     "editable": true,
+    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -859,6 +959,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebb47ddf-6fdf-4c76-b50d-e3483782d497",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pangeo_fish.helpers import normalize_pdf\n",
+    "combined = normalize_pdf(\n",
+    "    ds=emission_pdf,\n",
+    "    chunks=default_chunk_dims,\n",
+    "    dims=dims,\n",
+    ")[0]\n",
+    "combined.to_zarr(\n",
+    "    f\"{target_root}/combined.zarr\",\n",
+    "    mode=\"w\",\n",
+    "    consolidated=True,\n",
+    "    zarr_version=2,\n",
+    "    storage_options=storage_options,\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "45",
    "metadata": {},
@@ -932,7 +1054,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "d7641dd7-e9b1-4c57-a7a9-85031f039152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,14 +1065,26 @@
     "    chunks=default_chunk_dims,\n",
     "    inline_array=True,\n",
     "    storage_options=storage_options,\n",
-    ")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f8b0305-ceb0-4e0a-81a0-7f42163065f9",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
     "# Define the parameter's bounds and search for the best value\n",
     "params = optimize_pdf(\n",
     "    ds=emission,\n",
     "    earth_radius=earth_radius,\n",
     "    adjustment_factor=adjustment_factor,\n",
-    "    truncate=truncate,\n",
+    "    truncate=None,\n",
     "    maximum_speed=maximum_speed,\n",
+    "    conv_method=\"FoscatConv\",\n",
     "    tolerance=tolerance,\n",
     "    dims=dims,\n",
     "    # the results can be directly saved\n",
@@ -1151,6 +1285,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1160,7 +1299,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -332,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1dc2c1f9-6ed5-4d5f-b481-a0d83a0a1eb9",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,11 +342,11 @@
     "\n",
     "\n",
     "first_datetime = ds.time.values[0]\n",
-    "last_datetime  = ds.time.values[-1]\n",
+    "last_datetime = ds.time.values[-1]\n",
     "\n",
     "\n",
-    "first_day = np.datetime_as_string(first_datetime, unit='D')\n",
-    "last_day  = np.datetime_as_string(last_datetime, unit='D')\n",
+    "first_day = np.datetime_as_string(first_datetime, unit=\"D\")\n",
+    "last_day = np.datetime_as_string(last_datetime, unit=\"D\")\n",
     "\n",
     "print(first_day, last_day)"
    ]
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4b17884-5f97-4723-b08f-99aca6a99983",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,9 +370,9 @@
     "    maximum_latitude=bbox[\"latitude\"][1],\n",
     "    start_datetime=first_day,\n",
     "    end_datetime=last_day,\n",
-    " )\n",
+    ")\n",
     "\n",
-    "ds_zos= copernicusmarine.open_dataset(\n",
+    "ds_zos = copernicusmarine.open_dataset(\n",
     "    dataset_id=\"cmems_mod_ibi_phy-ssh_my_0.027deg_P1D-m\",\n",
     "    variables=[\"zos\"],\n",
     "    minimum_longitude=bbox[\"longitude\"][0],\n",
@@ -397,13 +397,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8c36b3d-b01b-48f1-887e-76cc0b7f2412",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
     "static_var = static_var.assign_coords(longitude=ds_thetao[\"longitude\"].values)\n",
     "\n",
-    "ds_all = xr.merge([ds_thetao,ds_zos, static_var], compat=\"no_conflicts\")\n",
+    "ds_all = xr.merge([ds_thetao, ds_zos, static_var], compat=\"no_conflicts\")\n",
     "ds_all = ds_all.rename({\"latitude\": \"lat\", \"longitude\": \"lon\"})\n",
     "model = prepare_dataset(ds_all)\n",
     "model"
@@ -412,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90e8c85c-2fa4-4144-8cbf-00917d44cca4",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b6109eb-2255-41e8-bb00-6a437ef1ceb9",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,11 +465,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7136974-6351-4b48-8aac-50b5eb9f111c",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pangeo_fish.helpers import compute_diff\n",
+    "\n",
     "diff = compute_diff(\n",
     "    reference_model=reference_model,\n",
     "    tag_log=tag_log,\n",
@@ -480,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "19",
    "metadata": {},
    "source": [
     "_We can detect abnormal data by looking at the number of non null values for each time step._"
@@ -489,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b579e381-6189-421a-8840-241ae8e17ab6",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,10 +511,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "22",
    "metadata": {
     "editable": true,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -521,14 +521,17 @@
    },
    "outputs": [],
    "source": [
-    "diff.to_zarr(f\"{target_root}/diff.zarr\", mode=\"w\",\n",
-    "             zarr_version=2,\n",
-    "             storage_options=storage_options)"
+    "diff.to_zarr(\n",
+    "    f\"{target_root}/diff.zarr\",\n",
+    "    mode=\"w\",\n",
+    "    zarr_version=2,\n",
+    "    storage_options=storage_options,\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "23",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -549,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "26",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -589,7 +592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "27",
    "metadata": {},
    "source": [
     "Let's plot the same chart as before to check that the HEALPix regridding hasn't changed the data"
@@ -598,7 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "28",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -614,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "29",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -637,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "30",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -658,7 +661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "31",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -674,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "32",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -706,7 +709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "33",
    "metadata": {},
    "source": [
     "Whatever the temporal distribution looks like, they must **never** (i.e, at _any time step_) sum to 0.\n",
@@ -717,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "34",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -734,7 +737,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "35",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -750,13 +753,13 @@
     "    mode=\"w\",\n",
     "    consolidated=True,\n",
     "    storage_options=storage_options,\n",
-    "    zarr_version=2\n",
+    "    zarr_version=2,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "36",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -778,7 +781,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,10 +791,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "38",
    "metadata": {
     "editable": true,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -818,7 +820,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "39",
    "metadata": {},
    "source": [
     "If you wonder how this emission matrix looks like, you can plot a combined plot of the detections and the probabilities:"
@@ -827,7 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "40",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -844,7 +846,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "41",
    "metadata": {},
    "source": [
     "### Explanations\n",
@@ -859,7 +861,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "42",
    "metadata": {},
    "source": [
     "**The next cell is optional. It will save the acoustic emission distribution. It is not necessary (see the next step).**"
@@ -868,7 +870,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +884,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "44",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -901,7 +903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "45",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -917,7 +919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "46",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -943,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "47",
    "metadata": {},
    "source": [
     "_**Tip:** in case you don't have acoustic detection (or you don't want to use it), you can normalize the `emission_pdf` with:_\n",
@@ -961,11 +963,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebb47ddf-6fdf-4c76-b50d-e3483782d497",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pangeo_fish.helpers import normalize_pdf\n",
+    "\n",
     "combined = normalize_pdf(\n",
     "    ds=emission_pdf,\n",
     "    chunks=default_chunk_dims,\n",
@@ -982,7 +985,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "49",
    "metadata": {},
    "source": [
     "**Let's perform a last check before fitting the model's parameters.**\n",
@@ -997,7 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1006,7 +1009,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "51",
    "metadata": {},
    "source": [
     "_The sums should equal to `1`._"
@@ -1014,7 +1017,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "52",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1038,7 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "53",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -1054,7 +1057,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7641dd7-e9b1-4c57-a7a9-85031f039152",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1071,10 +1074,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f8b0305-ceb0-4e0a-81a0-7f42163065f9",
-   "metadata": {
-    "scrolled": true
-   },
+   "id": "55",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Define the parameter's bounds and search for the best value\n",
@@ -1097,7 +1098,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "56",
    "metadata": {},
    "source": [
     "## 8. State probabilities and Trajectories\n",
@@ -1110,7 +1111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1120,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1136,7 +1137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "59",
    "metadata": {},
    "source": [
     "Let's quickly check that the positional probability distribution `states` never sums to 0 for all timesteps!"
@@ -1145,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1157,7 +1158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "61",
    "metadata": {},
    "source": [
     "## 9. Visualization\n",
@@ -1177,7 +1178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "62",
    "metadata": {},
    "source": [
     "### 9.1 Plotting the trajectories "
@@ -1186,7 +1187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1196,7 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,7 +1212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "65",
    "metadata": {},
    "source": [
     "### 9.2 Plotting the `states` and `emission` distributions "
@@ -1220,7 +1221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1230,7 +1231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1245,7 +1246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "68",
    "metadata": {},
    "source": [
     "The interactive plot above is too large to be stored as a `HMTL` file (as done earlier with the trajectories).\n",
@@ -1256,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1266,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1285,11 +1286,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1299,8 +1295,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -79,22 +79,14 @@
    "metadata": {
     "editable": true,
     "raw_mimetype": "",
+    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
     "tags": []
    },
    "source": [
-    "!pip install rich zstandard\n",
-    "# !pip install \"xarray-healpy @ git+https://github.com/iaocea/xarray-healpy.git@0ffca6058f4008f4f22f076e2d60787fcf32ac82\"\n",
-    "!pip install xhealpixify\n",
-    "!pip install -e ../.\n",
-    "!pip install more_itertools\n",
-    "!pip install movingpandas<='0.21.3'\n",
-    "!pip install 'xarray<=2025.04.0'\n",
-    "!pip install xdggs\n",
-    "!pip install healpix-convolution\n",
-    "!pip install --upgrade \"cf-xarray>=0.10.4\""
+    "!pip install -e ../."
    ]
   },
   {
@@ -135,8 +127,11 @@
     "# tag_root specifies the root URL for tag data used for this computation.\n",
     "tag_root = \"https://data-taos.ifremer.fr/data_tmp/cleaned/tag/\"\n",
     "\n",
-    "# ref_url is the path to the reference model\n",
-    "ref_url = \"https://data-taos.ifremer.fr/kerchunk/copernicus_model_NWSHELF_2022.json\"\n",
+    "# variable names from copernicusmarine services.\n",
+    "# thetao , zos , bathymetry \n",
+    "thetao_var_name = \"cmems_mod_ibi_phy-temp_my_0.027deg_P1D-m\"\n",
+    "zos_var_name = \"cmems_mod_ibi_phy-ssh_my_0.027deg_P1D-m\"\n",
+    "static_var_name = \"cmems_mod_ibi_phy_my_0.027deg-3D_static\"\n",
     "\n",
     "# scratch_root specifies the root directory for storing output files.\n",
     "# storage_options specifies options for the filesystem storing output files.\n",
@@ -362,7 +357,7 @@
     "from pangeo_fish.io import prepare_dataset\n",
     "\n",
     "ds_thetao = copernicusmarine.open_dataset(\n",
-    "    dataset_id=\"cmems_mod_ibi_phy-temp_my_0.027deg_P1D-m\",\n",
+    "    dataset_id=thetao_var_name,\n",
     "    variables=[\"thetao\"],\n",
     "    minimum_longitude=bbox[\"longitude\"][0],\n",
     "    maximum_longitude=bbox[\"longitude\"][1],\n",
@@ -373,7 +368,7 @@
     ")\n",
     "\n",
     "ds_zos = copernicusmarine.open_dataset(\n",
-    "    dataset_id=\"cmems_mod_ibi_phy-ssh_my_0.027deg_P1D-m\",\n",
+    "    dataset_id=zos_var_name,\n",
     "    variables=[\"zos\"],\n",
     "    minimum_longitude=bbox[\"longitude\"][0],\n",
     "    maximum_longitude=bbox[\"longitude\"][1],\n",
@@ -385,7 +380,7 @@
     "\n",
     "\n",
     "static_var = copernicusmarine.open_dataset(\n",
-    "    dataset_id=\"cmems_mod_ibi_phy_my_0.027deg-3D_static\",\n",
+    "    dataset_id=static_var_name,\n",
     "    variables=[\"deptho\", \"mask\"],\n",
     "    minimum_longitude=bbox[\"longitude\"][0],\n",
     "    maximum_longitude=bbox[\"longitude\"][1],\n",
@@ -1286,6 +1281,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1295,7 +1295,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -80,7 +80,6 @@
    "metadata": {
     "editable": true,
     "raw_mimetype": "",
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },
@@ -130,7 +129,7 @@
     "tag_root = \"https://data-taos.ifremer.fr/data_tmp/cleaned/tag/\"\n",
     "\n",
     "# variable names from copernicusmarine services.\n",
-    "# thetao , zos , bathymetry \n",
+    "# thetao , zos , bathymetry\n",
     "thetao_var_name = \"cmems_mod_ibi_phy-temp_my_0.027deg_P1D-m\"\n",
     "zos_var_name = \"cmems_mod_ibi_phy-ssh_my_0.027deg_P1D-m\"\n",
     "static_var_name = \"cmems_mod_ibi_phy_my_0.027deg-3D_static\"\n",
@@ -1283,11 +1282,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1297,8 +1291,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/pangeo_fish/helpers.py
+++ b/pangeo_fish/helpers.py
@@ -1099,7 +1099,7 @@ def _get_max_sigma(
             maximum_speed_ * timedelta * adjustment_factor / grid_resolution
         )
     max_sigma = max_grid_displacement.pint.to("dimensionless").pint.magnitude
-
+    print("Max sigma :", max_sigma)
     return max_sigma.item()
 
 

--- a/pangeo_fish/hmm/prediction.py
+++ b/pangeo_fish/hmm/prediction.py
@@ -115,7 +115,7 @@ class Foscat1DHealpix(Predictor):
 
         self.kernel_size = 33
         nside = 2**self.grid_info.level
-        
+
         self.stencil = sc.SphericalStencil(
             nside, int(self.kernel_size), cell_ids=self.cell_ids
         )
@@ -127,12 +127,12 @@ class Foscat1DHealpix(Predictor):
         )
         W = np.exp(-(xx**2 + yy**2) / (sigma_opt**2))
         W = W / W.sum()
-        
-        print("sigma",self.sigma)
-        print("sigma_opt",sigma_opt)
+
+        print("sigma", self.sigma)
+        print("sigma_opt", sigma_opt)
         print(W)
         print("kernel cut:", W[:, self.kernel_size // 2])
-        
+
         self.W_tensor = self.stencil.to_tensor(W).reshape(1, 1, self.kernel_size**2)
 
     def _ensure_bcp(self, arr: np.ndarray):

--- a/pangeo_fish/hmm/prediction.py
+++ b/pangeo_fish/hmm/prediction.py
@@ -115,7 +115,7 @@ class Foscat1DHealpix(Predictor):
 
         self.kernel_size = 33
         nside = 2**self.grid_info.level
-
+        
         self.stencil = sc.SphericalStencil(
             nside, int(self.kernel_size), cell_ids=self.cell_ids
         )
@@ -127,7 +127,12 @@ class Foscat1DHealpix(Predictor):
         )
         W = np.exp(-(xx**2 + yy**2) / (sigma_opt**2))
         W = W / W.sum()
-
+        
+        print("sigma",self.sigma)
+        print("sigma_opt",sigma_opt)
+        print(W)
+        print("kernel cut:", W[:, self.kernel_size // 2])
+        
         self.W_tensor = self.stencil.to_tensor(W).reshape(1, 1, self.kernel_size**2)
 
     def _ensure_bcp(self, arr: np.ndarray):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "healpix-convolution",
   "xdggs",
   "imageio[ffmpeg]",
+  "copernicusmarine>=2.4.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Refs #233

Copernicus Marine provides only daily product data, so the temporal resolution may not be as accurate for a "demo" tag. 
This update switches the example notebook to use Copernicus Marine reference data, using the `foscat` convolution.
