### PR TITLE
fix: update broken HEALPix link in tutorial notebook

### DIFF
--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -1146,11 +1146,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1160,8 +1155,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -429,7 +429,7 @@
    "source": [
     "## 3. HEALPix regridding\n",
     "\n",
-    "In this step, we regrid the data from above to HEALPix coordinates. HEALPix (Hierarchical Equal Area isoLatitude Pixelization) is a spherical pixelation scheme that divides the sphere into equal-area pixels, eliminating spatial distortion—[see the HEALPix documentation](https://healpix.jpl.nasa.gov/).\n",
+    "In this step, we regrid the data from above to HEALPix coordinates. HEALPix (Hierarchical Equal Area isoLatitude Pixelization) is a spherical pixelation scheme that divides the sphere into equal-area pixels, eliminating spatial distortion [see the HEALPix documentation](https://healpix.sourceforge.io/).\n",
     "\n",
     "This is a complex process, composed of several steps such as defining the HEALPix grid, creating the target grid and computing interpolation weights\n",
     "\n",
@@ -1146,6 +1146,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1155,7 +1160,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Related to #232

The HEALPix link in the tutorial notebook (section 3) was pointing 
to https://healpix.jpl.nasa.gov/ which is no longer maintained.

Updated to https://healpy.readthedocs.io/ which is the current 
Python HEALPix documentation.
