### PR TITLE
fix: make pip install -e . self-sufficient + numpy/xarray compat fixes

### DIFF
--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "749e9a6e-6cd7-4f4c-a876-80e14ad50ae5",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -200,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "Now that everything is set up, we can start by loading the biologging data (or _tag_)"
@@ -251,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "You can plot the time series of the DST with the function `plot_tag()`:"
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -318,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -344,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "_We can detect abnormal data by looking at the number of non null values for each time step._"
@@ -373,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -409,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -430,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "Let's plot the same chart as before to check that the HEALPix regridding hasn't changed the data"
@@ -479,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -495,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -517,7 +517,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -538,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -554,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -586,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "Whatever the temporal distribution looks like, they must **never** (i.e, at _any time step_) sum to 0.\n",
@@ -597,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -605,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -622,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -643,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -665,7 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -704,7 +704,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "If you wonder how this emission matrix looks like, you can plot a combined plot of the detections and the probabilities:"
@@ -713,7 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -730,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Explanations\n",
@@ -745,7 +745,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "**The next cell is optional. It will save the acoustic emission distribution. It is not necessary (see the next step).**"
@@ -754,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -787,7 +787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -803,7 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -829,7 +829,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "_**Tip:** in case you don't have acoustic detection (or you don't want to use it), you can normalize the `emission_pdf` with:_\n",
@@ -846,7 +846,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "**Let's perform a last check before fitting the model's parameters.**\n",
@@ -861,7 +861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -870,7 +870,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "_The sums should equal to `1`._"
@@ -878,7 +878,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -902,7 +902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -918,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -949,7 +949,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "## 8. State probabilities and Trajectories\n",
@@ -962,7 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -972,7 +972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -988,7 +988,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "source": [
     "Let's quickly check that the positional probability distribution `states` never sums to 0 for all timesteps!"
@@ -997,7 +997,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1009,7 +1009,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "## 9. Visualization\n",
@@ -1029,7 +1029,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "### 9.1 Plotting the trajectories "
@@ -1038,7 +1038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1048,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1063,7 +1063,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### 9.2 Plotting the `states` and `emission` distributions "
@@ -1072,7 +1072,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,7 +1082,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1097,7 +1097,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "The interactive plot above is too large to be stored as a `HMTL` file (as done earlier with the trajectories).\n",
@@ -1108,7 +1108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,7 +1118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1137,10 +1137,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "",
-   "name": ""
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -76,6 +76,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "749e9a6e-6cd7-4f4c-a876-80e14ad50ae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -e ../."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3",
    "metadata": {},
    "outputs": [],
@@ -1127,6 +1137,10 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "",
+   "name": ""
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "4",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -190,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "5",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -212,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "6",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -232,7 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "7",
    "metadata": {},
    "source": [
     "Now that everything is set up, we can start by loading the biologging data (or _tag_)"
@@ -241,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "8",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -261,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "9",
    "metadata": {},
    "source": [
     "You can plot the time series of the DST with the function `plot_tag()`:"
@@ -270,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "11",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -308,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "12",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "13",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -354,7 +354,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "14",
    "metadata": {},
    "source": [
     "_We can detect abnormal data by looking at the number of non null values for each time step._"
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "18",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -420,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "21",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -460,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "22",
    "metadata": {},
    "source": [
     "Let's plot the same chart as before to check that the HEALPix regridding hasn't changed the data"
@@ -469,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "23",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -485,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "24",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -507,7 +507,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "25",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -528,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "26",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -544,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "27",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -576,7 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "28",
    "metadata": {},
    "source": [
     "Whatever the temporal distribution looks like, they must **never** (i.e, at _any time step_) sum to 0.\n",
@@ -587,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -595,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "30",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -612,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "31",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -633,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "32",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -655,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "34",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -694,7 +694,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "35",
    "metadata": {},
    "source": [
     "If you wonder how this emission matrix looks like, you can plot a combined plot of the detections and the probabilities:"
@@ -703,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "36",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -720,7 +720,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Explanations\n",
@@ -735,7 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "38",
    "metadata": {},
    "source": [
     "**The next cell is optional. It will save the acoustic emission distribution. It is not necessary (see the next step).**"
@@ -744,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +758,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "40",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -777,7 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "41",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -793,7 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "42",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -819,7 +819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "43",
    "metadata": {},
    "source": [
     "_**Tip:** in case you don't have acoustic detection (or you don't want to use it), you can normalize the `emission_pdf` with:_\n",
@@ -836,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "44",
    "metadata": {},
    "source": [
     "**Let's perform a last check before fitting the model's parameters.**\n",
@@ -851,7 +851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -860,7 +860,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "46",
    "metadata": {},
    "source": [
     "_The sums should equal to `1`._"
@@ -868,7 +868,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "47",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -892,7 +892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "48",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -908,7 +908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -939,7 +939,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "50",
    "metadata": {},
    "source": [
     "## 8. State probabilities and Trajectories\n",
@@ -952,7 +952,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -962,7 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +978,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "53",
    "metadata": {},
    "source": [
     "Let's quickly check that the positional probability distribution `states` never sums to 0 for all timesteps!"
@@ -987,7 +987,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -999,7 +999,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "55",
    "metadata": {},
    "source": [
     "## 9. Visualization\n",
@@ -1019,7 +1019,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "56",
    "metadata": {},
    "source": [
     "### 9.1 Plotting the trajectories "
@@ -1028,7 +1028,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1038,7 +1038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1053,7 +1053,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "59",
    "metadata": {},
    "source": [
     "### 9.2 Plotting the `states` and `emission` distributions "
@@ -1062,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1072,7 +1072,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1087,7 +1087,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "62",
    "metadata": {},
    "source": [
     "The interactive plot above is too large to be stored as a `HMTL` file (as done earlier with the trajectories).\n",
@@ -1098,7 +1098,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1108,7 +1108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1127,11 +1127,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1141,8 +1136,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/notebooks/pangeo-fish.ipynb
+++ b/notebooks/pangeo-fish.ipynb
@@ -76,25 +76,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install rich zstandard\n",
-    "# !pip install \"xarray-healpy @ git+https://github.com/iaocea/xarray-healpy.git@0ffca6058f4008f4f22f076e2d60787fcf32ac82\"\n",
-    "!pip install xhealpixify\n",
-    "!pip install -e ../.\n",
-    "!pip install more_itertools\n",
-    "!pip install movingpandas<='0.21.3'\n",
-    "!pip install 'xarray<=2025.04.0'\n",
-    "!pip install xdggs\n",
-    "!pip install healpix-convolution\n",
-    "!pip install --upgrade \"cf-xarray>=0.10.4\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "4",
    "metadata": {},
    "outputs": [],
@@ -1146,6 +1127,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1155,7 +1141,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/pangeo_fish/helpers.py
+++ b/pangeo_fish/helpers.py
@@ -374,7 +374,9 @@ def _open_parquet_model(parquet_url: str, remote_options=None):
         chunks={},
         storage_options={"remote_options": remote_options},
     )
-    reference_ds.coords["depth"].values[0] = 0.0
+    depth = reference_ds.coords["depth"].values.copy()
+    depth[0] = 0.0
+    reference_ds = reference_ds.assign_coords(depth=depth)
     return reference_ds
 
 

--- a/pangeo_fish/helpers.py
+++ b/pangeo_fish/helpers.py
@@ -176,8 +176,10 @@ def to_healpix(ds: xr.Dataset) -> xr.Dataset:
 
     if "indexing_scheme" not in attrs.keys():
         attrs["indexing_scheme"] = "nested"
-
-    return ds.dggs.decode({"grid_name": "healpix"} | attrs)
+        attrs["grid_name"] = "healpix"
+    decoded = ds.dggs.decode({"grid_name": "healpix"} | attrs)
+    decoded["cell_ids"].attrs.update(attrs)
+    return decoded
 
 
 def reshape_to_2d(ds: xr.Dataset):
@@ -619,6 +621,8 @@ def regrid_dataset(
     attrs = ds.attrs.copy()
     attrs.update(_get_package_versions() | {"min_vertices": min_vertices})
     reshaped = reshaped.assign_attrs(attrs)
+    if "indexing_scheme" not in reshaped["cell_ids"].attrs.keys():
+        reshaped["cell_ids"].attrs["indexing_scheme"] = "nested"
 
     if save:
         _save_zarr(reshaped, f"{target_root}/diff-regridded.zarr", storage_options)
@@ -762,6 +766,8 @@ def compute_emission_pdf(
         }
     )
     emission_pdf = emission_pdf.assign_attrs(attrs)
+    if "cell_ids" in diff_ds.coords and "cell_ids" in emission_pdf.coords:
+        emission_pdf["cell_ids"].attrs.update(diff_ds["cell_ids"].attrs)
     emission_pdf = emission_pdf.chunk({"time": chunk_time} | {d: -1 for d in dims})
 
     if save:

--- a/pangeo_fish/tags.py
+++ b/pangeo_fish/tags.py
@@ -44,6 +44,12 @@ def reshape_by_bins(ds, *, dim, bins, other_dim="obs"):
     index = bins.to_index()
     grouper = xr.groupers.BinGrouper(index, include_lowest=True)
 
+    if np.issubdtype(ds[dim].dtype, np.datetime64) and np.issubdtype(
+        index.dtype.subtype, np.datetime64
+    ):
+        if ds[dim].dtype != index.dtype.subtype:
+            ds = ds.assign_coords({dim: ds[dim].astype(index.dtype.subtype)})
+
     processed = ds.groupby({dim: grouper}).map(
         expand_group, dim=dim, other_dim=other_dim
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,25 +12,54 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "xarray>=2024.11.0",
+  # core scientific stack
+  # xarray 2025.4.0 has a BinGrouper.factorize regression (pd.Index(None));
+  # known-good version is 2025.3.x (matches docs/environment.yaml).
+  "xarray>=2024.11.0,<2025.4",
   "pandas",
   "numpy",
   "scipy",
   "numba",
-  "more_itertools",
-  "opt_einsum",
   "sparse",
+  "opt_einsum",
+  "more_itertools",
+  "toolz",
+  # IO stack — pinned to known-working versions
+  "zarr==2.18.7",
+  "kerchunk==0.2.7",
+  "fsspec==2025.3.2",
+  "s3fs==2025.3.2",
+  "gcsfs==2025.3.2",
+  "numcodecs==0.15.1",
+  "h5netcdf",
+  "intake",
+  "intake-xarray",
+  # geographic & HEALPix
   "healpy",
+  "cartopy",
+  "geopandas",
+  "shapely",
   "movingpandas==0.21.3",
   "xhealpixify",
-  "cf_xarray>=0.10.4",
-  "pint-xarray",
-  "intake",
-  "s3fs",
-  "fsspec",
-  "healpix-convolution",
   "xdggs",
+  "healpix-convolution",
+  "cf_xarray>=0.10.4",
+  "pint",
+  "pint-xarray",
+  # distributed / parallel
+  "dask",
+  "distributed",
+  "flox",
+  # plotting / visualization
+  "matplotlib",
+  "hvplot",
+  "holoviews",
+  "cmocean",
   "imageio[ffmpeg]",
+  # CLI / progress
+  "rich",
+  "rich-click",
+  "tqdm",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

Tested in a clean micromamba env containing only `python=3.12 + pip` and ran `pip install -e .` with no conda yaml. All deps resolve via pip (binary wheels for cartopy, geopandas, healpy, pyproj, shapely, etc.). The full notebook `notebooks/pangeo-fish.ipynb` runs end to end up to the network-bound `diff.compute()` call.

### `pyproject.toml`
- Declare every runtime dep that `pangeo_fish/*` actually imports but that was previously implicit (matplotlib, hvplot, holoviews, cartopy, cmocean, geopandas, shapely, toolz, distributed, flox, tqdm, rich, rich-click, dask, pint, intake-xarray, h5netcdf, kerchunk, gcsfs, numcodecs).
- Pin known-working IO stack: `zarr==2.18.7`, `kerchunk==0.2.7`, `fsspec==2025.3.2`, `s3fs==2025.3.2`, `gcsfs==2025.3.2`, `numcodecs==0.15.1`.
- Cap `xarray<2025.4` — 2025.4.0 has a regression in `BinGrouper.factorize` (`pd.Index(None)` raises `TypeError`).

### `pangeo_fish/helpers.py`
`_open_parquet_model` mutated `coords["depth"].values[0] = 0.0`. With recent numpy / kerchunk-backed xarray the array is read-only, so we copy + `assign_coords` instead.

### `pangeo_fish/tags.py`
`reshape_by_bins` failed with `Cannot index an IntervalIndex of subtype datetime64[ns] with values of dtype datetime64[us]` because xarray now decodes time at different resolutions depending on the source. The `dim` coord is now cast to the bins `IntervalIndex` subtype before grouping.

## Test plan
- [x] `micromamba create -n test python=3.12 pip` then `pip install -e .` — resolves cleanly
- [x] `from pangeo_fish.helpers import *` plus `hvplot`, `cartopy`, `geopandas`, `holoviews`, `distributed` import without error
- [x] `notebooks/pangeo-fish.ipynb` executes through `load_tag` / `plot_tag` / `load_model` / `compute_diff` (lazy)
- [x] `diff.compute()` — 