### PR TITLE
fix: update dependency versions in pyproject.toml

### DIFF
--- a/pangeo_fish/acoustic.py
+++ b/pangeo_fish/acoustic.py
@@ -7,7 +7,6 @@ import healpy as hp
 import numpy as np
 import pandas as pd
 import xarray as xr
-from tlz.itertoolz import first
 from xhealpixify.conversions import geographic_to_cartesian
 from xhealpixify.operations import buffer_points
 

--- a/pangeo_fish/acoustic.py
+++ b/pangeo_fish/acoustic.py
@@ -41,10 +41,11 @@ def count_detections(detections, by):
     xarray.Dataset.groupby
     """
     if "bounds" in getattr(by, "dims", []):
-        if len(by.cf.bounds) != 1:
+        unique_bounds = {b for bounds in by.cf.bounds.values() for b in bounds}
+        if len(unique_bounds) != 1:
             raise ValueError("cannot find a valid bounds variable")
 
-        bounds_var = first(by.cf.bounds.values())[0]
+        bounds_var = next(iter(unique_bounds))
         bins_var = f"{bounds_var.removesuffix('_bounds')}_bins"
         by = bounds_to_bins(by)[bins_var]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ dependencies = [
   "pint-xarray",
   # distributed / parallel
   "copernicusmarine==2.3.0",
-  "dask",
-  "distributed",
+  "dask>=2026.3.0",
+  "distributed>=2026.3.0",
   "flox",
   # plotting / visualization
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,7 @@ classifiers = [
 ]
 dependencies = [
   # core scientific stack
-  # xarray 2025.4.0 has a BinGrouper.factorize regression (pd.Index(None));
-  # known-good version is 2025.3.x (matches docs/environment.yaml).
-  "xarray>=2024.11.0,<2025.4",
+  "xarray>=2026.4.0",
   "pandas",
   "numpy",
   "scipy",
@@ -25,8 +23,8 @@ dependencies = [
   "more_itertools",
   "toolz",
   # IO stack — pinned to known-working versions
-  "zarr==2.18.7",
-  "kerchunk==0.2.7",
+  "zarr>=3.1.6",
+  "kerchunk>=0.2.9",
   "fsspec==2025.3.2",
   "s3fs==2025.3.2",
   "gcsfs==2025.3.2",
@@ -47,8 +45,9 @@ dependencies = [
   "pint",
   "pint-xarray",
   # distributed / parallel
+  "copernicusmarine==2.3.0",
   "dask",
-  "distributed",
+  "distributed==2025.2.0",
   "flox",
   # plotting / visualization
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ dependencies = [
   # IO stack — pinned to known-working versions
   "zarr>=3.1.6",
   "kerchunk>=0.2.9",
-  "fsspec==2025.3.2",
-  "s3fs==2025.3.2",
-  "gcsfs==2025.3.2",
-  "numcodecs==0.15.1",
+  "fsspec>=2025.9.0",
+  "s3fs>=2025.9.0",
+  "gcsfs>=2025.9.0",
+  "numcodecs>=0.15.1",
   "h5netcdf",
   "intake",
   "intake-xarray",
@@ -47,7 +47,7 @@ dependencies = [
   # distributed / parallel
   "copernicusmarine==2.3.0",
   "dask",
-  "distributed==2025.2.0",
+  "distributed",
   "flox",
   # plotting / visualization
   "matplotlib",


### PR DESCRIPTION
Pin version so that it work on pangeo_eosc 

- Relax xarray upper bound to >=2026.4.0
- Upgrade zarr to >=3.1.6 (v3)
- Upgrade kerchunk to >=0.2.9
- Add copernicusmarine==2.3.0
- Pin distributed==2025.2.0